### PR TITLE
Signature2 hash

### DIFF
--- a/web3swift/Transaction/Classes/TransactionSigner.swift
+++ b/web3swift/Transaction/Classes/TransactionSigner.swift
@@ -37,6 +37,16 @@ public struct Web3Signer {
         return compressedSignature
     }
     
+    public static func signPersonalMessage2Hash(_ personalMessage: Data, keystore: AbstractKeystore, account: EthereumAddress, password: String, useExtraEntropy: Bool = true) throws -> Data? {
+        var privateKey = try keystore.UNSAFE_getPrivateKeyData(password: password, account: account)
+        defer {Data.zero(&privateKey)}
+        guard let hash = Web3.Utils.hashPersonalMessage(personalMessage) else {return nil}
+        let hash1 = hash.sha3(.keccak256)
+        let (compressedSignature, _) = SECP256K1.signForRecovery(hash: hash1, privateKey: privateKey, useExtraEntropy: useExtraEntropy)
+        return compressedSignature
+    }
+    
+    
     public struct EIP155Signer {
         public static func sign(transaction:inout EthereumTransaction, privateKey: Data, useExtraEntropy: Bool = true) throws {
             for _ in 0..<1024 {

--- a/web3swift/Web3/Classes/Web3+Utils.swift
+++ b/web3swift/Web3/Classes/Web3+Utils.swift
@@ -180,6 +180,18 @@ extension Web3.Utils {
         return Web3.Utils.publicToAddress(publicKey)
     }
     
+    static public func personalECRecover2Hash(_ personalMessage: Data, signature: Data) -> EthereumAddress? {
+        if signature.count != 65 { return nil}
+        let rData = signature[0..<32].bytes
+        let sData = signature[32..<64].bytes
+        let vData = signature[64]
+        guard let signatureData = SECP256K1.marshalSignature(v: vData, r: rData, s: sData) else {return nil}
+        guard let hash = Web3.Utils.hashPersonalMessage(personalMessage) else {return nil}
+        let hash1 = hash.sha3(.keccak256)
+        guard let publicKey = SECP256K1.recoverPublicKey(hash: hash1, signature: signatureData) else {return nil}
+        return Web3.Utils.publicToAddress(publicKey)
+    }
+    
     static public func hashECRecover(hash: Data, signature: Data) -> EthereumAddress? {
         if signature.count != 65 { return nil}
         let rData = signature[0..<32].bytes

--- a/web3swiftTests/web3swiftTests.swift
+++ b/web3swiftTests/web3swiftTests.swift
@@ -2089,6 +2089,91 @@ class web3swiftTests: XCTestCase {
         }
     }
     
+
+    
+    func testPersonalSignature2HashOnContract() {
+        
+        
+        let abiString = "[{\"constant\":true,\"inputs\":[{\"name\":\"v\",\"type\":\"uint8\"},{\"name\":\"r\",\"type\":\"bytes32\"},{\"name\":\"s\",\"type\":\"bytes32\"},{\"name\":\"number\",\"type\":\"uint256\"}],\"name\":\"validate\",\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\"},{\"name\":\"\",\"type\":\"address\"},{\"name\":\"\",\"type\":\"bool\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[],\"name\":\"kill\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"v\",\"type\":\"uint8\"},{\"name\":\"r\",\"type\":\"bytes32\"},{\"name\":\"s\",\"type\":\"bytes32\"},{\"name\":\"_stepsNumber\",\"type\":\"uint256\"}],\"name\":\"exchange\",\"outputs\":[{\"name\":\"\",\"type\":\"bool\"}],\"payable\":true,\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"name\":\"_rate\",\"type\":\"uint256\"},{\"name\":\"_quota\",\"type\":\"uint256\"}],\"payable\":true,\"stateMutability\":\"payable\",\"type\":\"constructor\"}]"
+        
+        
+        
+        
+        let contractAddress = EthereumAddress("0xe143869afd05e83ffcb2a59b65334c9e2bdc5efd")
+        let url = URL.init(string: "http://192.168.82.77:8545")
+        // let url = URL.init(string: "http://127.0.0.1:8545")
+        let web3 = Web3.new(url!)
+        
+        
+        let testString = "1000"
+        let personalMessage  = testString.data(using: String.Encoding.utf8)
+        print(personalMessage)
+        
+        let tempKeystore = try! EthereumKeystoreV3(password: "")
+        let keystoreManager = KeystoreManager([tempKeystore!])
+        web3?.addKeystoreManager(keystoreManager)
+        let expectedAddress = keystoreManager.addresses![0]
+        print(expectedAddress)
+     
+    
+        do {
+            
+            
+            let signature = try Web3Signer.signPersonalMessage2Hash(personalMessage!, keystore: keystoreManager, account: expectedAddress, password: "",useExtraEntropy: false)
+            
+            print(signature)
+            
+            if signature?.count != 65 { print("sign count error")}
+            
+            let rData = Data(signature![0..<32])
+            let sData = Data(signature![32..<64])
+            let vData = BigUInt(signature![64]) + BigUInt(27)
+            print(rData)
+            print(sData)
+            print(vData)
+            print(signature?.toHexString())
+            
+            
+            let contract = web3?.contract(abiString, at: contractAddress, abiVersion: 2)
+            var options = Web3Options.defaultOptions()
+            options.from = expectedAddress
+            
+            let parameters = [vData,rData,sData,BigUInt(1000)] as [AnyObject]
+            
+            print("parameters:")
+            print(parameters)
+            let intermediate = contract?.method("validate",parameters: parameters, options: options)
+            let result = intermediate!.call(options: options)
+            
+            print("v result")
+            print(result)
+            switch result {
+            case .success(let payload):
+                print(payload)
+            case .failure(let error):
+                print(error)
+                
+            }
+            
+        
+            //验签
+            let verifySender: EthereumAddress = Web3.Utils.personalECRecover2Hash(personalMessage!, signature: signature!)!
+            print("verify sender:")
+            print(verifySender)
+            
+            print("\n")
+            
+            
+        }
+        catch{
+            print(error)
+            
+        }
+        
+        
+    }
+    
+
     func testUserCaseEventParsing() {
         let contractAddress = EthereumAddress("0x7ff546aaccd379d2d1f241e1d29cdd61d4d50778")
         let jsonString = "[{\"constant\":false,\"inputs\":[{\"name\":\"_id\",\"type\":\"string\"}],\"name\":\"deposit\",\"outputs\":[],\"payable\":true,\"stateMutability\":\"payable\",\"type\":\"function\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"_from\",\"type\":\"address\"},{\"indexed\":false,\"name\":\"_id\",\"type\":\"string\"},{\"indexed\":true,\"name\":\"_value\",\"type\":\"uint256\"}],\"name\":\"Deposit\",\"type\":\"event\"}]"
@@ -2107,6 +2192,6 @@ class web3swiftTests: XCTestCase {
             // Put the code you want to measure the time of here.
         }
     }
-    
+ 
 }
 

--- a/web3swiftTests/web3swiftTests.swift
+++ b/web3swiftTests/web3swiftTests.swift
@@ -2100,8 +2100,8 @@ class web3swiftTests: XCTestCase {
         
         
         let contractAddress = EthereumAddress("0xe143869afd05e83ffcb2a59b65334c9e2bdc5efd")
-        let url = URL.init(string: "http://192.168.82.77:8545")
-        // let url = URL.init(string: "http://127.0.0.1:8545")
+        //let url = URL.init(string: "http://192.168.82.77:8545")
+         let url = URL.init(string: "http://127.0.0.1:8545")
         let web3 = Web3.new(url!)
         
         


### PR DESCRIPTION
hi, 
my signature use  hash 2 times .
And web3j ,the Java and Android library for integration with Ethereum clients( https://github.com/web3j/web3j) signature use hash 2 times.
so, I add the "signPersonalMessage2Hash" method  to signature and "personalECRecover2Hash" to verify.
pls, add them.