### PR TITLE
Add publc initializer to EventFilter

### DIFF
--- a/web3swift/Contract/Classes/ContractProtocol.swift
+++ b/web3swift/Contract/Classes/ContractProtocol.swift
@@ -66,6 +66,16 @@ public struct EventFilter {
             }
         }
     }
+    
+    public init(fromBlock: Block?, toBlock: Block?,
+                addresses: [EthereumAddress]? = nil,
+                parameterFilters: [[EventFilterable]?]? = nil) {
+        self.fromBlock = fromBlock
+        self.toBlock = toBlock
+        self.addresses = addresses
+        self.parameterFilters = parameterFilters
+    }
+    
     public var fromBlock: Block?
     public var toBlock: Block?
     public var addresses: [EthereumAddress]?


### PR DESCRIPTION
In Swift 4 default structs' initializers have an internal modifier
therefore, it was not possible to construct EventFilter in client
code