### PR TITLE
Make 'removed' flag optional in EventLog

### DIFF
--- a/web3swift/Web3/Classes/Web3+Structures.swift
+++ b/web3swift/Web3/Classes/Web3+Structures.swift
@@ -130,7 +130,7 @@ public struct EventLog {
         guard let ad = json["address"] as? String else {return nil}
         guard let d = json["data"] as? String else {return nil}
         guard let li = json["logIndex"] as? String else {return nil}
-        guard let rm = json["removed"] as? Int else {return nil}
+        let rm = json["removed"] as? Int ?? 0
         guard let tpc = json["topics"] as? [String] else {return nil}
         guard let addr = EthereumAddress(ad) else {return nil}
         address = addr


### PR DESCRIPTION
In some cases, blockchain returns records with no 'removed' flag i.e. removed=false. The old code failed to fetch event log with such deviation.