### PR TITLE
Concurrency marked as deprecated, some functions deleted

### DIFF
--- a/web3swift/Concurrency/Classes/Web3+Concurrency.swift
+++ b/web3swift/Concurrency/Classes/Web3+Concurrency.swift
@@ -11,6 +11,7 @@ import Result
 
 public typealias Callback = ((Result<AnyObject, Web3Error>) -> ())
 
+@available(*, deprecated)
 public class OperationDispatcher {
     public var MAX_WAIT_TIME: TimeInterval = 0.2
     private var provider: Web3Provider
@@ -188,6 +189,7 @@ protocol OperationProtocol{
     var error: Web3Error? {get set}
 }
 
+@available(*, deprecated)
 public class Web3Operation: Operation, OperationProtocol {
     var web3: web3
     

--- a/web3swift/Concurrency/Classes/Web3+ConversionOperations.swift
+++ b/web3swift/Concurrency/Classes/Web3+ConversionOperations.swift
@@ -10,6 +10,7 @@ import Foundation
 import Result
 import BigInt
 
+@available(*, deprecated)
 final class ResultUnwrapOperation: Web3Operation {
     override func main() {
         if (error != nil) {
@@ -28,6 +29,7 @@ final class ResultUnwrapOperation: Web3Operation {
     }
 }
 
+@available(*, deprecated)
 final class ConversionOperation<T>: Web3Operation {
     override func main() {
         if (error != nil) {
@@ -40,6 +42,7 @@ final class ConversionOperation<T>: Web3Operation {
     }
 }
 
+@available(*, deprecated)
 final class BigUIntConversionOperation: Web3Operation {
     
     override func main() {
@@ -65,6 +68,7 @@ final class BigUIntConversionOperation: Web3Operation {
     }
 }
 
+@available(*, deprecated)
 final class JSONasDataConversionOperation: Web3Operation {
     
     override func main() {
@@ -90,6 +94,7 @@ final class JSONasDataConversionOperation: Web3Operation {
     }
 }
 
+@available(*, deprecated)
 final class DictionaryConversionOperation: Web3Operation {
     
     override func main() {
@@ -112,6 +117,7 @@ final class DictionaryConversionOperation: Web3Operation {
     }
 }
 
+@available(*, deprecated)
 final class StringDictionaryConversionOperation: Web3Operation {
     
     override func main() {
@@ -134,6 +140,7 @@ final class StringDictionaryConversionOperation: Web3Operation {
     }
 }
 
+@available(*, deprecated)
 final class AddressArrayConversionOperation: Web3Operation {
     
     override func main() {
@@ -165,6 +172,7 @@ final class AddressArrayConversionOperation: Web3Operation {
     }
 }
 
+@available(*, deprecated)
 final class DataConversionOperation: Web3Operation {
     
     override func main() {
@@ -190,6 +198,7 @@ final class DataConversionOperation: Web3Operation {
     }
 }
 
+@available(*, deprecated)
 final class StringConversionOperation: Web3Operation {
     
     override func main() {
@@ -212,6 +221,7 @@ final class StringConversionOperation: Web3Operation {
     }
 }
 
+@available(*, deprecated)
 final class JoinOperation: Web3Operation {
     convenience init(_ web3Instance: web3, queue: OperationQueue? = nil, operations: [Web3Operation]) {
         self.init(web3Instance, queue: queue, inputData: operations as AnyObject)

--- a/web3swift/Concurrency/Classes/Web3+DataFetchOperation.swift
+++ b/web3swift/Concurrency/Classes/Web3+DataFetchOperation.swift
@@ -9,6 +9,7 @@
 import Foundation
 import Result
 
+@available(*, deprecated)
 final class DataFetchOperation: Web3Operation {
     
     override func main() {
@@ -24,6 +25,7 @@ final class DataFetchOperation: Web3Operation {
     }
 }
 
+@available(*, deprecated)
 final class NoBatchingDataFetchOperation: Web3Operation {
     
     override func main() {

--- a/web3swift/Concurrency/Classes/Web3+EthOperations.swift
+++ b/web3swift/Concurrency/Classes/Web3+EthOperations.swift
@@ -11,6 +11,7 @@ import Result
 import BigInt
 
 
+@available(*, deprecated)
 final class GetAccountsOperation: Web3Operation {
     override func main() {
         if (error != nil) {
@@ -36,6 +37,7 @@ final class GetAccountsOperation: Web3Operation {
     }
 }
 
+@available(*, deprecated)
 final class GetTransactionCountOperation: Web3Operation {
     convenience init(_ web3Instance: web3, queue: OperationQueue? = nil, address: EthereumAddress, onBlock: String = "latest") {
         let addressString = address.address.lowercased()
@@ -67,6 +69,7 @@ final class GetTransactionCountOperation: Web3Operation {
     }
 }
 
+@available(*, deprecated)
 final class GetBalanceOperation: Web3Operation {
     convenience init(_ web3Instance: web3, queue: OperationQueue? = nil, address: EthereumAddress, onBlock: String = "latest") {
         let addressString = address.address.lowercased()
@@ -98,6 +101,7 @@ final class GetBalanceOperation: Web3Operation {
     }
 }
 
+@available(*, deprecated)
 final class GetBlockNumberOperation: Web3Operation {
     override func main() {
         if (error != nil) {
@@ -114,6 +118,7 @@ final class GetBlockNumberOperation: Web3Operation {
     }
 }
 
+@available(*, deprecated)
 final class GetGasPriceOperation: Web3Operation {
     override func main() {
         if (error != nil) {
@@ -130,6 +135,7 @@ final class GetGasPriceOperation: Web3Operation {
     }
 }
 
+@available(*, deprecated)
 final class EstimateGasOperation: Web3Operation {
     convenience init(_ web3Instance: web3, queue: OperationQueue? = nil, transaction: EthereumTransaction, options: Web3Options?,  onBlock: String = "latest") {
         self.init(web3Instance, queue: queue, inputData: [transaction, options as Any, onBlock] as AnyObject)
@@ -163,6 +169,7 @@ final class EstimateGasOperation: Web3Operation {
     }
 }
 
+@available(*, deprecated)
 final class CallOperation: Web3Operation {
     convenience init(_ web3Instance: web3, queue: OperationQueue? = nil, transaction: EthereumTransaction, options: Web3Options?, onBlock: String = "latest") {
         self.init(web3Instance, queue: queue, inputData: [transaction, options as Any, onBlock] as AnyObject)
@@ -197,6 +204,7 @@ final class CallOperation: Web3Operation {
     }
 }
 
+@available(*, deprecated)
 final class SendTransactionOperation: Web3Operation {
     convenience init(_ web3Instance: web3, queue: OperationQueue? = nil, transaction: EthereumTransaction, options: Web3Options?, password:String = "BANKEXFOUNDATION") {
         self.init(web3Instance, queue: queue, inputData: [transaction, options as Any, password] as AnyObject)
@@ -250,6 +258,7 @@ final class SendTransactionOperation: Web3Operation {
     }
 }
 
+@available(*, deprecated)
 final class SendRawTransactionOperation: Web3Operation {
     convenience init(_ web3Instance: web3, queue: OperationQueue? = nil, transaction: EthereumTransaction) {
         self.init(web3Instance, queue: queue, inputData: transaction as AnyObject)

--- a/web3swift/Concurrency/Classes/Web3+EventOperations.swift
+++ b/web3swift/Concurrency/Classes/Web3+EventOperations.swift
@@ -10,6 +10,7 @@ import Foundation
 import Result
 import BigInt
 
+@available(*, deprecated)
 final class ParseBlockForEventsOperation: Web3Operation {
     
     convenience init?(_ web3Instance: web3, queue: OperationQueue? = nil, contract: ContractProtocol, eventName: String, filter: EventFilter? = nil, block: UInt64) {
@@ -86,6 +87,7 @@ final class ParseBlockForEventsOperation: Web3Operation {
 }
 
 
+@available(*, deprecated)
 final class ParseTransactionForEventsOperation: Web3Operation {
     
     convenience init?(_ web3Instance: web3, queue: OperationQueue? = nil, contract: ContractProtocol, eventName: String, filter: EventFilter? = nil, transactionHash: Data) {

--- a/web3swift/Concurrency/Classes/Web3+NativePrimitivesConversionOperations.swift
+++ b/web3swift/Concurrency/Classes/Web3+NativePrimitivesConversionOperations.swift
@@ -10,6 +10,7 @@ import Foundation
 import Result
 import BigInt
 
+@available(*, deprecated)
 final class TransactionReceiptConversionOperation: Web3Operation {
     
     override func main() {
@@ -29,6 +30,7 @@ final class TransactionReceiptConversionOperation: Web3Operation {
     }
 }
 
+@available(*, deprecated)
 final class TransactionDetailsConversionOperation: Web3Operation {
     
     override func main() {
@@ -48,6 +50,7 @@ final class TransactionDetailsConversionOperation: Web3Operation {
     }
 }
 
+@available(*, deprecated)
 final class BlockConversionOperation: Web3Operation {
     
     override func main() {

--- a/web3swift/Concurrency/Classes/Web3+PersonalOperations.swift
+++ b/web3swift/Concurrency/Classes/Web3+PersonalOperations.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-
+@available(*, deprecated)
 final class PersonalUnlockAccountOperation: Web3Operation {
     convenience init(_ web3Instance: web3, queue: OperationQueue? = nil, account: EthereumAddress, password: String = "BANKEXFOUNDATION", seconds: UInt64 = 300) {
         let addressString = account.address.lowercased()
@@ -41,6 +41,7 @@ final class PersonalUnlockAccountOperation: Web3Operation {
     }
 }
 
+@available(*, deprecated)
 final class PersonalSignOperation: Web3Operation {
     
     convenience init(_ web3Instance: web3, queue: OperationQueue? = nil, message: Data, from: EthereumAddress, password:String = "BANKEXFOUNDATION") {

--- a/web3swift/Concurrency/Classes/Web3+TransactionAndBlockDetailsOperations.swift
+++ b/web3swift/Concurrency/Classes/Web3+TransactionAndBlockDetailsOperations.swift
@@ -9,6 +9,7 @@
 import Foundation
 import BigInt
 
+@available(*, deprecated)
 final class GetTransactionDetailsOperation: Web3Operation {
     
     convenience init(_ web3Instance: web3, queue: OperationQueue? = nil, txHash: String) {
@@ -38,7 +39,7 @@ final class GetTransactionDetailsOperation: Web3Operation {
     }
 }
 
-
+@available(*, deprecated)
 final class GetTransactionReceiptOperation: Web3Operation {
     
     convenience init(_ web3Instance: web3, queue: OperationQueue? = nil, txHash: String) {
@@ -68,6 +69,7 @@ final class GetTransactionReceiptOperation: Web3Operation {
     }
 }
 
+@available(*, deprecated)
 final class GetBlockByNumberOperation: Web3Operation {
     convenience init(_ web3Instance: web3, queue: OperationQueue? = nil, blockNumber: UInt64, fullTransactions: Bool = false) {
         let blockNumberString = String(blockNumber, radix: 16).addHexPrefix()
@@ -105,6 +107,7 @@ final class GetBlockByNumberOperation: Web3Operation {
     }
 }
 
+@available(*, deprecated)
 final class GetBlockByHashOperation: Web3Operation {
     convenience init(_ web3Instance: web3, queue: OperationQueue? = nil, hash: String, fullTransactions: Bool = false) {
         self.init(web3Instance, queue: queue, inputData: [hash, fullTransactions] as AnyObject)

--- a/web3swift/Concurrency/Classes/Web3+TransactionOperations.swift
+++ b/web3swift/Concurrency/Classes/Web3+TransactionOperations.swift
@@ -10,6 +10,7 @@ import Foundation
 import Result
 import BigInt
 
+@available(*, deprecated)
 final class ContractCallOperation: Web3Operation {
     var method: String?
     
@@ -113,6 +114,7 @@ final class ContractCallOperation: Web3Operation {
 }
 
 
+@available(*, deprecated)
 final class ContractEstimateGasOperation: Web3Operation {
     
     convenience init?(_ web3Instance: web3, queue: OperationQueue? = nil, contract: web3.web3contract, method: String = "fallback", parameters: [AnyObject] = [], extraData: Data = Data(), options: Web3Options?, onBlock: String = "latest") {
@@ -140,6 +142,7 @@ final class ContractEstimateGasOperation: Web3Operation {
     }
 }
 
+@available(*, deprecated)
 final class ContractSendOperation: Web3Operation {
     
     convenience init?(_ web3Instance: web3, queue: OperationQueue? = nil, contract: web3.web3contract, method: String = "fallback", parameters: [AnyObject] = [], extraData: Data = Data(), options: Web3Options?, onBlock: String = "pending", password: String = "BANKEXFOUNDATION") {

--- a/web3swift/Convenience/Classes/CryptoExtensions.swift
+++ b/web3swift/Convenience/Classes/CryptoExtensions.swift
@@ -14,12 +14,6 @@ func toByteArray<T>(_ value: T) -> [UInt8] {
     return withUnsafeBytes(of: &value) { Array($0) }
 }
 
-func fromByteArray<T>(_ value: [UInt8], _: T.Type) -> T {
-    return value.withUnsafeBytes {
-        $0.baseAddress!.load(as: T.self)
-    }
-}
-
 public func scrypt (password: String, salt: Data, length: Int, N: Int, R: Int, P: Int) -> Data? {
     let BytesMin = Int(crypto_generichash_bytes_min())
     let BytesMax = Int(crypto_generichash_bytes_max())

--- a/web3swift/Convenience/Classes/Dictionary+Extension.swift
+++ b/web3swift/Convenience/Classes/Dictionary+Extension.swift
@@ -8,12 +8,6 @@
 
 import Foundation
 
-extension Dictionary where Value: Equatable {
-    func containsValue(value : Value) -> Bool {
-        return self.contains { $0.1 == value }
-    }
-}
-
 extension Dictionary where Key == String, Value: Equatable {
     func keyForValue(value : Value) -> String? {
         for key in self.keys {

--- a/web3swift/Convenience/Classes/String+Extension.swift
+++ b/web3swift/Convenience/Classes/String+Extension.swift
@@ -8,13 +8,6 @@ extension String {
     var fullNSRange: NSRange {
         return NSRange(fullRange, in: self)
     }
-
-    func lastIndex(of char: Character) -> Index? {
-        guard let range = range(of: String(char), options: .backwards) else {
-            return nil
-        }
-        return range.lowerBound
-    }
     
     func index(of char: Character) -> Index? {
         guard let range = range(of: String(char)) else {

--- a/web3swift/Web3/Classes/Web3.swift
+++ b/web3swift/Web3/Classes/Web3.swift
@@ -62,10 +62,6 @@ struct ResultUnwrapper {
     }
 }
 
-func isInstanceOf <T>(instance: Any, of kind: T.Type) -> Bool {
-    return instance is T;
-}
-
 
 
 


### PR DESCRIPTION
Unused functions are deleted. Also I've found a file called Web3+Deprecated.swift with public struct EventParser with exactly the same functionality as in Web3+EventParser.swift. Won't it be right to delete deprecated one?