### PR TITLE
let JsonRpcRequestDispatcher init function public for custom use

### DIFF
--- a/Sources/web3swift/Web3/Batching.swift
+++ b/Sources/web3swift/Web3/Batching.swift
@@ -22,7 +22,7 @@ public class JsonRpcRequestDispatcher {
     private var lockQueue: DispatchQueue
     private var batches: [Batch] = [Batch]()
 
-    init(provider: Web3Provider, queue: DispatchQueue, policy: DispatchPolicy) {
+    public init(provider: Web3Provider, queue: DispatchQueue, policy: DispatchPolicy) {
         self.provider = provider
         self.queue = queue
         self.policy = policy


### PR DESCRIPTION
Web3 init function contains a JsonRpcRequestDispatcher parameter but it only has internal init function.